### PR TITLE
feat: proxy (Tor/SOCKS5) support: add optional proxy parameter

### DIFF
--- a/lib/src/core/client/impl/tezart_client.dart
+++ b/lib/src/core/client/impl/tezart_client.dart
@@ -23,7 +23,8 @@ class TezartClient {
   final RpcInterface rpcInterface;
 
   /// Default constructor.
-  TezartClient(String url) : rpcInterface = RpcInterface(url);
+  TezartClient(String url, {String? proxy})
+      : rpcInterface = RpcInterface(url, proxy: proxy);
 
   /// Returns an [OperationsList] containing a [TransactionOperation] that transfers [amount] from [source]
   /// to [destination] and returns the operation group id.\
@@ -51,18 +52,20 @@ class TezartClient {
     bool reveal = true,
   }) async {
     return _catchHttpError<OperationsList>(() async {
-      log.info('request transfer $amount µtz from $source.address to the destination $destination');
+      log.info(
+          'request transfer $amount µtz from $source.address to the destination $destination');
 
-      final operationsList = OperationsList(source: source, rpcInterface: rpcInterface)
-        ..appendOperation(
-          TransactionOperation(
-            amount: amount,
-            destination: destination,
-            customFee: customFee,
-            customGasLimit: customGasLimit,
-            customStorageLimit: customStorageLimit,
-          ),
-        );
+      final operationsList =
+          OperationsList(source: source, rpcInterface: rpcInterface)
+            ..appendOperation(
+              TransactionOperation(
+                amount: amount,
+                destination: destination,
+                customFee: customFee,
+                customGasLimit: customGasLimit,
+                customStorageLimit: customStorageLimit,
+              ),
+            );
       if (reveal) {
         await _prependRevealIfNotRevealed(
           operationsList,

--- a/lib/src/core/client/impl/tezart_client.dart
+++ b/lib/src/core/client/impl/tezart_client.dart
@@ -52,20 +52,18 @@ class TezartClient {
     bool reveal = true,
   }) async {
     return _catchHttpError<OperationsList>(() async {
-      log.info(
-          'request transfer $amount µtz from $source.address to the destination $destination');
+      log.info('request transfer $amount µtz from $source.address to the destination $destination');
 
-      final operationsList =
-          OperationsList(source: source, rpcInterface: rpcInterface)
-            ..appendOperation(
-              TransactionOperation(
-                amount: amount,
-                destination: destination,
-                customFee: customFee,
-                customGasLimit: customGasLimit,
-                customStorageLimit: customStorageLimit,
-              ),
-            );
+      final operationsList = OperationsList(source: source, rpcInterface: rpcInterface)
+        ..appendOperation(
+          TransactionOperation(
+            amount: amount,
+            destination: destination,
+            customFee: customFee,
+            customGasLimit: customGasLimit,
+            customStorageLimit: customStorageLimit,
+          ),
+        );
       if (reveal) {
         await _prependRevealIfNotRevealed(
           operationsList,

--- a/lib/src/core/rpc/impl/rpc_interface.dart
+++ b/lib/src/core/rpc/impl/rpc_interface.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 import 'dart:convert';
+
 import 'package:logging/logging.dart';
 import 'package:memoize/memoize.dart';
 import 'package:tezart/src/core/rpc/impl/operations_monitor.dart';
 import 'package:tezart/src/models/operations_list/operations_list.dart';
 
-import 'tezart_http_client.dart';
 import 'rpc_interface_paths.dart' as paths;
+import 'tezart_http_client.dart';
 
 /// A class that handles the calls to a Tezos RPC Node
 ///
@@ -17,12 +18,14 @@ class RpcInterface {
   final TezartHttpClient httpClient;
   final log = Logger('RpcInterface');
 
-  RpcInterface(String url) : httpClient = TezartHttpClient(url);
+  RpcInterface(String url, {String? proxy})
+      : httpClient = TezartHttpClient(url, proxy: proxy);
 
   /// Returns the block's hash of [chain] and [level]
   Future<String> branch([chain = 'main', level = 'head']) async {
     log.info('request for branch [ chain:$chain, level:$level]');
-    var response = await httpClient.get(paths.branch(chain: chain, level: level));
+    var response =
+        await httpClient.get(paths.branch(chain: chain, level: level));
 
     return response.data;
   }
@@ -38,7 +41,8 @@ class RpcInterface {
   /// Returns the protocol of [chain] and [level]
   Future<String> protocol([chain = 'main', level = 'head']) async {
     log.info('request for protocol [ chain:$chain, level:$level]');
-    var response = await httpClient.get(paths.protocol(chain: chain, level: level));
+    var response =
+        await httpClient.get(paths.protocol(chain: chain, level: level));
 
     return response.data['protocol'];
   }
@@ -46,7 +50,8 @@ class RpcInterface {
   /// Returns the counter of [source] in the chain defined by [chain] and [level]
   Future<int> counter(String source, [chain = 'main', level = 'head']) async {
     log.info('request for counter [ chain:$chain, level:$level]');
-    final response = await httpClient.get(paths.counter(source: source, chain: chain, level: level));
+    final response = await httpClient
+        .get(paths.counter(source: source, chain: chain, level: level));
 
     return int.parse(response.data);
   }
@@ -62,21 +67,28 @@ class RpcInterface {
   /// Injects the forged operation [data] in [chain] and returns the operation id
   Future<String> injectOperation(String data, [chain = 'main']) async {
     log.info('request for injectOperation [ chain:$chain]');
-    final response = await httpClient.post(paths.injectOperation(chain), data: jsonEncode(data));
+    final response = await httpClient.post(paths.injectOperation(chain),
+        data: jsonEncode(data));
 
     return response.data;
   }
 
   /// Returns the forged operation of [operationsList] in the chain defined by [chain] and [level]
-  Future<String> forgeOperations(OperationsList operationsList, [chain = 'main', level = 'head']) async {
+  Future<String> forgeOperations(OperationsList operationsList,
+      [chain = 'main', level = 'head']) async {
     log.info('request for forgeOperations [ chain:$chain, level:$level]');
     var content = {
       'branch': await branch(),
-      'contents': operationsList.operations.map((operation) => operation.toJson()).toList(),
+      'contents': operationsList.operations
+          .map((operation) => operation.toJson())
+          .toList(),
     };
 
-    return memo1<Map<String, Object>, Future<String>>((Map<String, Object> content) async {
-      final response = await httpClient.post(paths.forgeOperations(chain: chain, level: level), data: content);
+    return memo1<Map<String, Object>, Future<String>>(
+        (Map<String, Object> content) async {
+      final response = await httpClient.post(
+          paths.forgeOperations(chain: chain, level: level),
+          data: content);
       return response.data;
     })(content);
   }
@@ -92,7 +104,9 @@ class RpcInterface {
     final content = [
       {
         'branch': await branch(),
-        'contents': operationsList.operations.map((operation) => operation.toJson()).toList(),
+        'contents': operationsList.operations
+            .map((operation) => operation.toJson())
+            .toList(),
         'signature': signature,
         'protocol': await protocol(chain, level),
       }
@@ -111,18 +125,22 @@ class RpcInterface {
   }
 
   /// Same as [preapplyOperations] but uses a random signature
-  Future<List<dynamic>> runOperations(OperationsList operationsList, [chain = 'main', level = 'head']) async {
+  Future<List<dynamic>> runOperations(OperationsList operationsList,
+      [chain = 'main', level = 'head']) async {
     log.info('request for runOperations [ chain:$chain, level:$level]');
     var content = {
       'operation': {
         'branch': await branch(),
-        'contents': operationsList.operations.map((operation) => operation.toJson()).toList(),
+        'contents': operationsList.operations
+            .map((operation) => operation.toJson())
+            .toList(),
         'signature': _randomSignature
       },
       'chain_id': await chainId()
     };
 
-    var response = await httpClient.post(paths.runOperations(chain: chain, level: level), data: content);
+    var response = await httpClient
+        .post(paths.runOperations(chain: chain, level: level), data: content);
 
     return response.data['contents'];
   }
@@ -130,9 +148,11 @@ class RpcInterface {
   /// Returns the public key of [address]
   ///
   /// If the address is unknown by the node, it returns null
-  Future<String?> managerKey(String address, [chain = 'main', level = 'head']) async {
+  Future<String?> managerKey(String address,
+      [chain = 'main', level = 'head']) async {
     log.info('request for managerKey [ chain:$chain, level:$level]');
-    var response = await httpClient.get(paths.managerKey(address: address, chain: chain, level: level));
+    var response = await httpClient
+        .get(paths.managerKey(address: address, chain: chain, level: level));
 
     return response.data;
   }
@@ -140,22 +160,26 @@ class RpcInterface {
   /// Returns the balance of [address] in the chain defined by [chain] and [level]
   Future<int> balance(String address, [chain = 'main', level = 'head']) async {
     log.info('request for balance [ chain:$chain, level:$level]');
-    var response = await httpClient.get(paths.balance(chain: chain, level: level, address: address));
+    var response = await httpClient
+        .get(paths.balance(chain: chain, level: level, address: address));
 
     return int.parse(response.data['balance']);
   }
 
   /// Returns the complete status of the contract whom address is [address]
-  Future<Map<String, dynamic>> getContract(String address, [chain = 'main', level = 'head']) async {
+  Future<Map<String, dynamic>> getContract(String address,
+      [chain = 'main', level = 'head']) async {
     log.info('request for contract : $address');
 
-    var response = await httpClient.get(paths.contract(chain: chain, level: level, contractAddress: address));
+    var response = await httpClient.get(
+        paths.contract(chain: chain, level: level, contractAddress: address));
 
     return response.data;
   }
 
   /// Returns a map containing the entrypoints and their types of a contract defined by [address]
-  Future<Map<String, dynamic>> getContractEntrypoints(String address, [chain = 'main', level = 'head']) async {
+  Future<Map<String, dynamic>> getContractEntrypoints(String address,
+      [chain = 'main', level = 'head']) async {
     log.info('request for contract entrypoints : $address');
 
     return memo1<String, Future<Map<String, dynamic>>>((String address) async {
@@ -178,7 +202,8 @@ class RpcInterface {
   }) async {
     log.info('request for contract : $address, entrypoint: $entrypoint');
 
-    return memo2<String, String, Future<Map<String, dynamic>>>((String address, String entrypoint) async {
+    return memo2<String, String, Future<Map<String, dynamic>>>(
+        (String address, String entrypoint) async {
       var response = await httpClient.get(paths.contractEntrypoint(
         chain: chain,
         level: level,
@@ -212,23 +237,30 @@ class RpcInterface {
     chain = 'main',
     level = 'head',
   }) async {
-    return _operationsMonitor.monitor(chain: chain, level: level, operationId: operationId);
+    return _operationsMonitor.monitor(
+        chain: chain, level: level, operationId: operationId);
   }
 
-  OperationsMonitor get _operationsMonitor => memo0(() => OperationsMonitor(this))();
+  OperationsMonitor get _operationsMonitor =>
+      memo0(() => OperationsMonitor(this))();
 
   /// Returns the block hash of [chain] and [level]
-  Future<Map<String, dynamic>> block({required String chain, required String level}) async {
-    final response = await httpClient.get(paths.block(chain: chain, level: level));
+  Future<Map<String, dynamic>> block(
+      {required String chain, required String level}) async {
+    final response =
+        await httpClient.get(paths.block(chain: chain, level: level));
 
     return response.data;
   }
 
   /// Returns the constants of the chain defined by [chain] and [level]
-  Future<Map<String, dynamic>> constants([chain = 'main', level = 'head']) async {
-    return memo2<String, String, Future<Map<String, dynamic>>>((String chain, String level) async {
+  Future<Map<String, dynamic>> constants(
+      [chain = 'main', level = 'head']) async {
+    return memo2<String, String, Future<Map<String, dynamic>>>(
+        (String chain, String level) async {
       log.info('request to constants');
-      final response = await httpClient.get(paths.constants(chain: chain, level: level));
+      final response =
+          await httpClient.get(paths.constants(chain: chain, level: level));
 
       return response.data;
     })(chain, level);
@@ -248,7 +280,8 @@ class RpcInterface {
       'data': data,
       'type': type,
     };
-    final response = await httpClient.post(paths.pack(chain: chain, level: level), data: content);
+    final response = await httpClient
+        .post(paths.pack(chain: chain, level: level), data: content);
 
     return response.data['packed'];
   }

--- a/lib/src/core/rpc/impl/rpc_interface.dart
+++ b/lib/src/core/rpc/impl/rpc_interface.dart
@@ -1,13 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
-
 import 'package:logging/logging.dart';
 import 'package:memoize/memoize.dart';
 import 'package:tezart/src/core/rpc/impl/operations_monitor.dart';
 import 'package:tezart/src/models/operations_list/operations_list.dart';
 
-import 'rpc_interface_paths.dart' as paths;
 import 'tezart_http_client.dart';
+import 'rpc_interface_paths.dart' as paths;
 
 /// A class that handles the calls to a Tezos RPC Node
 ///
@@ -24,8 +23,7 @@ class RpcInterface {
   /// Returns the block's hash of [chain] and [level]
   Future<String> branch([chain = 'main', level = 'head']) async {
     log.info('request for branch [ chain:$chain, level:$level]');
-    var response =
-        await httpClient.get(paths.branch(chain: chain, level: level));
+    var response = await httpClient.get(paths.branch(chain: chain, level: level));
 
     return response.data;
   }
@@ -41,8 +39,7 @@ class RpcInterface {
   /// Returns the protocol of [chain] and [level]
   Future<String> protocol([chain = 'main', level = 'head']) async {
     log.info('request for protocol [ chain:$chain, level:$level]');
-    var response =
-        await httpClient.get(paths.protocol(chain: chain, level: level));
+    var response = await httpClient.get(paths.protocol(chain: chain, level: level));
 
     return response.data['protocol'];
   }
@@ -50,8 +47,7 @@ class RpcInterface {
   /// Returns the counter of [source] in the chain defined by [chain] and [level]
   Future<int> counter(String source, [chain = 'main', level = 'head']) async {
     log.info('request for counter [ chain:$chain, level:$level]');
-    final response = await httpClient
-        .get(paths.counter(source: source, chain: chain, level: level));
+    final response = await httpClient.get(paths.counter(source: source, chain: chain, level: level));
 
     return int.parse(response.data);
   }
@@ -67,28 +63,21 @@ class RpcInterface {
   /// Injects the forged operation [data] in [chain] and returns the operation id
   Future<String> injectOperation(String data, [chain = 'main']) async {
     log.info('request for injectOperation [ chain:$chain]');
-    final response = await httpClient.post(paths.injectOperation(chain),
-        data: jsonEncode(data));
+    final response = await httpClient.post(paths.injectOperation(chain), data: jsonEncode(data));
 
     return response.data;
   }
 
   /// Returns the forged operation of [operationsList] in the chain defined by [chain] and [level]
-  Future<String> forgeOperations(OperationsList operationsList,
-      [chain = 'main', level = 'head']) async {
+  Future<String> forgeOperations(OperationsList operationsList, [chain = 'main', level = 'head']) async {
     log.info('request for forgeOperations [ chain:$chain, level:$level]');
     var content = {
       'branch': await branch(),
-      'contents': operationsList.operations
-          .map((operation) => operation.toJson())
-          .toList(),
+      'contents': operationsList.operations.map((operation) => operation.toJson()).toList(),
     };
 
-    return memo1<Map<String, Object>, Future<String>>(
-        (Map<String, Object> content) async {
-      final response = await httpClient.post(
-          paths.forgeOperations(chain: chain, level: level),
-          data: content);
+    return memo1<Map<String, Object>, Future<String>>((Map<String, Object> content) async {
+      final response = await httpClient.post(paths.forgeOperations(chain: chain, level: level), data: content);
       return response.data;
     })(content);
   }
@@ -104,9 +93,7 @@ class RpcInterface {
     final content = [
       {
         'branch': await branch(),
-        'contents': operationsList.operations
-            .map((operation) => operation.toJson())
-            .toList(),
+        'contents': operationsList.operations.map((operation) => operation.toJson()).toList(),
         'signature': signature,
         'protocol': await protocol(chain, level),
       }
@@ -125,22 +112,18 @@ class RpcInterface {
   }
 
   /// Same as [preapplyOperations] but uses a random signature
-  Future<List<dynamic>> runOperations(OperationsList operationsList,
-      [chain = 'main', level = 'head']) async {
+  Future<List<dynamic>> runOperations(OperationsList operationsList, [chain = 'main', level = 'head']) async {
     log.info('request for runOperations [ chain:$chain, level:$level]');
     var content = {
       'operation': {
         'branch': await branch(),
-        'contents': operationsList.operations
-            .map((operation) => operation.toJson())
-            .toList(),
+        'contents': operationsList.operations.map((operation) => operation.toJson()).toList(),
         'signature': _randomSignature
       },
       'chain_id': await chainId()
     };
 
-    var response = await httpClient
-        .post(paths.runOperations(chain: chain, level: level), data: content);
+    var response = await httpClient.post(paths.runOperations(chain: chain, level: level), data: content);
 
     return response.data['contents'];
   }
@@ -148,11 +131,9 @@ class RpcInterface {
   /// Returns the public key of [address]
   ///
   /// If the address is unknown by the node, it returns null
-  Future<String?> managerKey(String address,
-      [chain = 'main', level = 'head']) async {
+  Future<String?> managerKey(String address, [chain = 'main', level = 'head']) async {
     log.info('request for managerKey [ chain:$chain, level:$level]');
-    var response = await httpClient
-        .get(paths.managerKey(address: address, chain: chain, level: level));
+    var response = await httpClient.get(paths.managerKey(address: address, chain: chain, level: level));
 
     return response.data;
   }
@@ -160,26 +141,22 @@ class RpcInterface {
   /// Returns the balance of [address] in the chain defined by [chain] and [level]
   Future<int> balance(String address, [chain = 'main', level = 'head']) async {
     log.info('request for balance [ chain:$chain, level:$level]');
-    var response = await httpClient
-        .get(paths.balance(chain: chain, level: level, address: address));
+    var response = await httpClient.get(paths.balance(chain: chain, level: level, address: address));
 
     return int.parse(response.data['balance']);
   }
 
   /// Returns the complete status of the contract whom address is [address]
-  Future<Map<String, dynamic>> getContract(String address,
-      [chain = 'main', level = 'head']) async {
+  Future<Map<String, dynamic>> getContract(String address, [chain = 'main', level = 'head']) async {
     log.info('request for contract : $address');
 
-    var response = await httpClient.get(
-        paths.contract(chain: chain, level: level, contractAddress: address));
+    var response = await httpClient.get(paths.contract(chain: chain, level: level, contractAddress: address));
 
     return response.data;
   }
 
   /// Returns a map containing the entrypoints and their types of a contract defined by [address]
-  Future<Map<String, dynamic>> getContractEntrypoints(String address,
-      [chain = 'main', level = 'head']) async {
+  Future<Map<String, dynamic>> getContractEntrypoints(String address, [chain = 'main', level = 'head']) async {
     log.info('request for contract entrypoints : $address');
 
     return memo1<String, Future<Map<String, dynamic>>>((String address) async {
@@ -202,8 +179,7 @@ class RpcInterface {
   }) async {
     log.info('request for contract : $address, entrypoint: $entrypoint');
 
-    return memo2<String, String, Future<Map<String, dynamic>>>(
-        (String address, String entrypoint) async {
+    return memo2<String, String, Future<Map<String, dynamic>>>((String address, String entrypoint) async {
       var response = await httpClient.get(paths.contractEntrypoint(
         chain: chain,
         level: level,
@@ -237,30 +213,23 @@ class RpcInterface {
     chain = 'main',
     level = 'head',
   }) async {
-    return _operationsMonitor.monitor(
-        chain: chain, level: level, operationId: operationId);
+    return _operationsMonitor.monitor(chain: chain, level: level, operationId: operationId);
   }
 
-  OperationsMonitor get _operationsMonitor =>
-      memo0(() => OperationsMonitor(this))();
+  OperationsMonitor get _operationsMonitor => memo0(() => OperationsMonitor(this))();
 
   /// Returns the block hash of [chain] and [level]
-  Future<Map<String, dynamic>> block(
-      {required String chain, required String level}) async {
-    final response =
-        await httpClient.get(paths.block(chain: chain, level: level));
+  Future<Map<String, dynamic>> block({required String chain, required String level}) async {
+    final response = await httpClient.get(paths.block(chain: chain, level: level));
 
     return response.data;
   }
 
   /// Returns the constants of the chain defined by [chain] and [level]
-  Future<Map<String, dynamic>> constants(
-      [chain = 'main', level = 'head']) async {
-    return memo2<String, String, Future<Map<String, dynamic>>>(
-        (String chain, String level) async {
+  Future<Map<String, dynamic>> constants([chain = 'main', level = 'head']) async {
+    return memo2<String, String, Future<Map<String, dynamic>>>((String chain, String level) async {
       log.info('request to constants');
-      final response =
-          await httpClient.get(paths.constants(chain: chain, level: level));
+      final response = await httpClient.get(paths.constants(chain: chain, level: level));
 
       return response.data;
     })(chain, level);
@@ -280,8 +249,7 @@ class RpcInterface {
       'data': data,
       'type': type,
     };
-    final response = await httpClient
-        .post(paths.pack(chain: chain, level: level), data: content);
+    final response = await httpClient.post(paths.pack(chain: chain, level: level), data: content);
 
     return response.data['packed'];
   }

--- a/lib/src/core/rpc/impl/tezart_http_client.dart
+++ b/lib/src/core/rpc/impl/tezart_http_client.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 
 import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart' as http_client;
-import 'package:logging/logging.dart';
 import 'package:pretty_dio_logger/pretty_dio_logger.dart';
+import 'package:logging/logging.dart';
 import 'package:retry/retry.dart';
 
 import 'tezart_http_error.dart';
@@ -55,8 +55,7 @@ class TezartHttpClient {
     );
   }
 
-  Future<http_client.Response> get(String path,
-      {Map<String, dynamic>? params}) {
+  Future<http_client.Response> get(String path, {Map<String, dynamic>? params}) {
     log.info('request to get from path: $path');
 
     return _retryOnSocketException(

--- a/lib/src/core/rpc/impl/tezart_http_client.dart
+++ b/lib/src/core/rpc/impl/tezart_http_client.dart
@@ -1,8 +1,9 @@
 import 'dart:io';
 
+import 'package:dio/adapter.dart';
 import 'package:dio/dio.dart' as http_client;
-import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 import 'package:logging/logging.dart';
+import 'package:pretty_dio_logger/pretty_dio_logger.dart';
 import 'package:retry/retry.dart';
 
 import 'tezart_http_error.dart';
@@ -13,26 +14,36 @@ class TezartHttpClient {
   final String url;
 
   // Add client as optional parameter for testing
-  TezartHttpClient(this.url, {http_client.Dio? client}) {
+  TezartHttpClient(this.url, {http_client.Dio? client, String? proxy}) {
     // ensure that the url ends with '/' (double / is ok)
     final baseUrl = '$url/';
 
     if (client != null) {
       this.client = client;
       this.client.options.baseUrl = baseUrl;
-      return;
-    }
+    } else {
+      var options = http_client.BaseOptions(
+          baseUrl: baseUrl, contentType: 'application/json');
 
-    final options = http_client.BaseOptions(baseUrl: baseUrl, contentType: 'application/json');
-    this.client = http_client.Dio(options);
-    this.client.interceptors.add(PrettyDioLogger(
-          logPrint: log.finest,
-          requestHeader: true,
-          requestBody: true,
-          responseBody: true,
-          responseHeader: false,
-          compact: false,
-        ));
+      this.client = http_client.Dio(options);
+      this.client.interceptors.add(PrettyDioLogger(
+            logPrint: log.finest,
+            requestHeader: true,
+            requestBody: true,
+            responseBody: true,
+            responseHeader: false,
+            compact: false,
+          ));
+
+      if (proxy != null) {
+        this.client.httpClientAdapter = DefaultHttpClientAdapter()
+          ..onHttpClientCreate = (HttpClient httpClient) {
+            httpClient.findProxy = (_) => 'PROXY $proxy';
+            // Ignore SSL errors if required for development with self-signed certificates
+            httpClient.badCertificateCallback = (cert, host, port) => true;
+          };
+      }
+    }
   }
 
   Future<http_client.Response> post(String path, {dynamic data}) {
@@ -44,7 +55,8 @@ class TezartHttpClient {
     );
   }
 
-  Future<http_client.Response> get(String path, {Map<String, dynamic>? params}) {
+  Future<http_client.Response> get(String path,
+      {Map<String, dynamic>? params}) {
     log.info('request to get from path: $path');
 
     return _retryOnSocketException(


### PR DESCRIPTION
Adds an optional proxy parameter to TezartClient, RpcInterface, etc., that allows requests to be proxied through a SOCKS5 proxy like Tor.  For existing users, nothing is changed.

You can see an example of usage at https://github.com/cypherstack/stack_wallet/blob/6c4f266a1caabfb7983f5b59f500f63619c8a69b/lib/wallets/wallet/impl/tezos_wallet.dart#L111

Stack Wallet is currently using this code to use `tezart` over Tor using the embeddable Tor proxy we helped make, https://github.com/Foundation-Devices/tor

Thank you for your library!  I hope this helps someone else use Tezos more privately.

Closes #102 